### PR TITLE
Pruebas manifiesto capera

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,16 @@
-// app.module.ts
+// src/app.module.ts
 import {Module} from '@nestjs/common';
 import {UsersModule} from './users/users.module';
 import {AuthModule} from './auth/auth.module';
 import {MailModule} from './mail/mail.module';
+import {ManifestsModule} from './interface/controllers/manifests.module';
 
 @Module({
-  imports: [UsersModule, AuthModule, MailModule]
+  imports: [
+    UsersModule,
+    AuthModule,
+    MailModule,
+    ManifestsModule // << agregar aquí
+  ]
 })
 export class AppModule {}

--- a/src/application/manifests/use-cases/get-paquetes.use-case.ts
+++ b/src/application/manifests/use-cases/get-paquetes.use-case.ts
@@ -1,0 +1,12 @@
+import {Injectable} from '@nestjs/common';
+import {PrismaManifestRepository} from 'src/infrastructure/persistence/prisma/prisma-manifest.repository';
+import {Paquete} from 'src/domain/manifests/entities/paquete.entity';
+
+@Injectable()
+export class GetPaquetesUseCase {
+  constructor(private readonly manifestRepo: PrismaManifestRepository) {}
+
+  async execute(codigo: string): Promise<Paquete[]> {
+    return this.manifestRepo.getPaquetesPorManifiesto(codigo);
+  }
+}

--- a/src/domain/manifests/entities/paquete.entity.ts
+++ b/src/domain/manifests/entities/paquete.entity.ts
@@ -1,0 +1,25 @@
+import {paquete_estado_paquete, paquete_tipo_paquete} from '@prisma/client';
+
+export class Paquete {
+  codigo_rastreo: string | null;
+  direccion: string;
+  largo: number;
+  ancho: number;
+  alto: number;
+  peso: number;
+  estado_paquete: paquete_estado_paquete;
+  tipo_paquete: paquete_tipo_paquete;
+
+  constructor(data: {
+    codigo_rastreo: string | null;
+    direccion: string;
+    largo: number;
+    ancho: number;
+    alto: number;
+    peso: number;
+    estado_paquete: paquete_estado_paquete;
+    tipo_paquete: paquete_tipo_paquete;
+  }) {
+    Object.assign(this, data);
+  }
+}

--- a/src/infrastructure/infrastructure.module.ts
+++ b/src/infrastructure/infrastructure.module.ts
@@ -1,7 +1,8 @@
-// src/infrastructure/infrastructure.module.ts
+// infrastructure.module.ts
 import {Module} from '@nestjs/common';
 import {FirebaseAuthProvider} from './auth/firebase-auth.provider';
 import {PrismaUserRepository} from './persistence/prisma/prisma-user.repository';
+import {PrismaManifestRepository} from './persistence/prisma/prisma-manifest.repository';
 import {PrismaService} from './persistence/prisma/prisma.service';
 import {USER_REPOSITORY} from 'src/domain/users/tokens/user-repository.token';
 
@@ -17,8 +18,15 @@ import {USER_REPOSITORY} from 'src/domain/users/tokens/user-repository.token';
       useClass: PrismaUserRepository
     },
     PrismaUserRepository,
+    PrismaManifestRepository, // << agregado
     PrismaService
   ],
-  exports: [FirebaseAuthProvider, 'AuthProvider', USER_REPOSITORY, PrismaService]
+  exports: [
+    FirebaseAuthProvider,
+    'AuthProvider',
+    USER_REPOSITORY,
+    PrismaManifestRepository, // << exportamos para otros módulos
+    PrismaService
+  ]
 })
 export class InfrastructureModule {}

--- a/src/infrastructure/persistence/prisma/prisma-manifest.repository.ts
+++ b/src/infrastructure/persistence/prisma/prisma-manifest.repository.ts
@@ -1,0 +1,30 @@
+import {Injectable} from '@nestjs/common';
+import {PrismaService} from './prisma.service';
+import {Paquete} from 'src/domain/manifests/entities/paquete.entity';
+
+@Injectable()
+export class PrismaManifestRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getPaquetesPorManifiesto(codigo: string): Promise<Paquete[]> {
+    const paquetes = await this.prisma.paquete.findMany({
+      where: {
+        ruta: {
+          cod_manifiesto: codigo // busca paquetes cuya ruta tiene ese código de manifiesto
+        }
+      },
+      select: {
+        codigo_rastreo: true,
+        direccion: true,
+        largo: true,
+        ancho: true,
+        alto: true,
+        peso: true,
+        estado_paquete: true,
+        tipo_paquete: true
+      }
+    });
+
+    return paquetes as Paquete[];
+  }
+}

--- a/src/interface/controllers/manifests.controller.ts
+++ b/src/interface/controllers/manifests.controller.ts
@@ -1,0 +1,17 @@
+//src/interface/controllers/manifests.module.ts
+import {Controller, Get, Param} from '@nestjs/common';
+import {GetPaquetesUseCase} from 'src/application/manifests/use-cases/get-paquetes.use-case';
+import {Paquete} from 'src/domain/manifests/entities/paquete.entity';
+
+@Controller('api/manifiestos')
+export class ManifestsController {
+  constructor(private readonly getPaquetesUseCase: GetPaquetesUseCase) {}
+
+  @Get(':codigo')
+  async getPaquetes(
+    @Param('codigo') codigo: string
+  ): Promise<{codigo: string; paquetes: Paquete[]}> {
+    const paquetes = await this.getPaquetesUseCase.execute(codigo);
+    return {codigo, paquetes};
+  }
+}

--- a/src/interface/controllers/manifests.module.ts
+++ b/src/interface/controllers/manifests.module.ts
@@ -1,0 +1,11 @@
+import {Module} from '@nestjs/common';
+import {ManifestsController} from './manifests.controller';
+import {GetPaquetesUseCase} from 'src/application/manifests/use-cases/get-paquetes.use-case';
+import {InfrastructureModule} from 'src/infrastructure/infrastructure.module';
+
+@Module({
+  imports: [InfrastructureModule],
+  controllers: [ManifestsController],
+  providers: [GetPaquetesUseCase]
+})
+export class ManifestsModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,8 @@ async function bootstrap() {
   app.enableCors({
     origin: [
       'http://localhost:5173', // Frontend local (Vite)
-      'https://route-manager.vercel.app' // Deploy en Vercel
+      'https://route-manager.vercel.app',
+      'https://7774a93b263b.ngrok-free.app'
     ],
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     allowedHeaders: 'Content-Type, Authorization',

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,6 @@ import {NestFactory} from '@nestjs/core';
 import {AppModule} from './app.module';
 
 async function bootstrap() {
-  // 👇 Ajustar DATABASE_URL dinámicamente
-  if (process.env.NODE_ENV === 'production' && process.env.DATABASE_URL_PROD) {
-    process.env.DATABASE_URL = process.env.DATABASE_URL_PROD;
-  }
-
   const app = await NestFactory.create(AppModule);
 
   // ✅ Habilitar CORS para local y producción


### PR DESCRIPTION
Se creó un endpoint GET /api/manifiestos/:codigo que permite obtener todos los paquetes asociados a un manifiesto.
Incluye:
- Controller ManifestsController
- Use case GetPaquetesUseCase
- Repositorio PrismaManifestRepository
- Integración con PrismaService para consultar la base de datos